### PR TITLE
Convert Pillager to Villager

### DIFF
--- a/src/main/java/com/shynieke/ageingmobs/config/AgeingConfig.java
+++ b/src/main/java/com/shynieke/ageingmobs/config/AgeingConfig.java
@@ -25,6 +25,8 @@ public class AgeingConfig {
 
 		public final BooleanValue huskToZombieAgeing;
 		public final IntValue huskToZombieAgeingTime;
+		public final BooleanValue passivePillagerToVillagerAgeing;
+		public final IntValue passivePillagerToVillagerAgeingTime;
 
 		public final BooleanValue villagerToVindicatorAgeing;
 		public final IntValue villagerToVindicatorAgeingTime;
@@ -111,6 +113,19 @@ public class AgeingConfig {
 			huskToZombieAgeingTime = builder
 					.comment("This specifies the time in second(s) which dictates how long a mob needs to age (Default: 30)")
 					.defineInRange("huskToZombieAgeingTime", 30, 1, Integer.MAX_VALUE);
+
+			builder.pop();
+
+			builder.comment("Passive Pillager -> Villager")
+					.push("passive_pillager_to_villager");
+
+			passivePillagerToVillagerAgeing = builder
+					.comment("Setting this to false disables the pillager -> villager ageing if the pillager is not holding a bow-like item (Default: true)")
+					.define("passivePillagerToVillagerAgeing", true);
+
+			passivePillagerToVillagerAgeingTime = builder
+					.comment("This specifies the time in second(s) which dictates how long a mob needs to age (Default: 300)")
+					.defineInRange("passivePillagerToVillagerAgeingTime", 300, 1, Integer.MAX_VALUE);
 
 			builder.pop();
 

--- a/src/main/java/com/shynieke/ageingmobs/registry/AgeingRegistry.java
+++ b/src/main/java/com/shynieke/ageingmobs/registry/AgeingRegistry.java
@@ -10,6 +10,7 @@ import com.shynieke.ageingmobs.registry.ageing.criteria.BiomeTypeCriteria;
 import com.shynieke.ageingmobs.registry.ageing.criteria.BlockBasedCriteria;
 import com.shynieke.ageingmobs.registry.ageing.criteria.BossCriteria;
 import com.shynieke.ageingmobs.registry.ageing.criteria.DimensionCriteria;
+import com.shynieke.ageingmobs.registry.ageing.criteria.EntityStateCriteria;
 import com.shynieke.ageingmobs.registry.ageing.criteria.LightCriteria;
 import com.shynieke.ageingmobs.registry.ageing.criteria.MagicCriteria;
 import com.shynieke.ageingmobs.registry.ageing.criteria.WeatherCriteria;
@@ -18,7 +19,9 @@ import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.CrossbowItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -104,6 +107,19 @@ public class AgeingRegistry {
 			if (babyHuskToBabyZombie.getAgeingTme() != ageingTime) {
 				babyHuskToBabyZombie.setAgeingTme(ageingTime);
 				INSTANCE.replaceAgeing(babyHuskToBabyZombie);
+			}
+		}
+
+		if (INSTANCE.isIDUnique(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.PILLAGER), "PassivePillagerToVillager") && AgeingConfig.COMMON.passivePillagerToVillagerAgeing.get()) {
+			AgeingData passivePillagerToVillager = new AgeingData("PassivePillagerToVillager", EntityType.PILLAGER, createNBTTag(""), EntityType.VILLAGER, createNBTTag(""), AgeingConfig.COMMON.passivePillagerToVillagerAgeingTime.get());
+			passivePillagerToVillager.setCriteria(new BaseCriteria[]{new EntityStateCriteria(passivePillagerToVillager, entity -> entity instanceof LivingEntity living && !living.isHolding(stack -> stack.getItem() instanceof CrossbowItem))});
+			INSTANCE.registerAgeing(passivePillagerToVillager);
+		} else if (!INSTANCE.isIDUnique(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.PILLAGER), "PassivePillagerToVillager")) {
+			AgeingData passivePillagerToVillager = INSTANCE.getByID(ForgeRegistries.ENTITY_TYPES.getKey(EntityType.PILLAGER), "PassivePillagerToVillager");
+			int ageingTime = AgeingConfig.COMMON.passivePillagerToVillagerAgeingTime.get();
+			if (passivePillagerToVillager.getAgeingTme() != ageingTime) {
+				passivePillagerToVillager.setAgeingTme(ageingTime);
+				INSTANCE.registerAgeing(passivePillagerToVillager);
 			}
 		}
 

--- a/src/main/java/com/shynieke/ageingmobs/registry/ageing/criteria/EntityStateCriteria.java
+++ b/src/main/java/com/shynieke/ageingmobs/registry/ageing/criteria/EntityStateCriteria.java
@@ -1,0 +1,30 @@
+package com.shynieke.ageingmobs.registry.ageing.criteria;
+
+import com.shynieke.ageingmobs.registry.ageing.iAgeing;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+
+import java.util.function.Predicate;
+
+public class EntityStateCriteria extends BaseCriteria {
+
+    private Predicate<Entity> stateChecker;
+
+    public EntityStateCriteria(iAgeing ageing, Predicate<Entity> stateChecker) {
+        super(ageing);
+        this.stateChecker = stateChecker;
+    }
+
+    public Predicate<Entity> getStateChecker() {
+        return this.stateChecker;
+    }
+
+    public void setStateChecker(Predicate<Entity> stateChecker) {
+        this.stateChecker = stateChecker;
+    }
+
+    @Override
+    public boolean checkCriteria(Level level, Entity entityIn) {
+        return this.getStateChecker().test(entityIn);
+    }
+}


### PR DESCRIPTION
Closes #4 

Converts pillagers to villagers if the pillager is no longer holding a crossbow. The conversion time takes five minutes by default.